### PR TITLE
feat: Add Vercel config and fix frontend API calls

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "./src/server.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/src/server.js"
+    }
+  ]
+}


### PR DESCRIPTION
This commit introduces two major fixes to enable a successful deployment on Vercel.

1.  **Add Backend Vercel Configuration:**
    -   A `backend/vercel.json` file has been added to instruct Vercel on how to deploy the Node.js Express server correctly. This resolves the "No Output Directory named 'public' found" build error.

2.  **Refactor Frontend API Calls:**
    -   Refactors multiple components (`AnnouncementBanner`, `HealthTipsSection`, etc.) to use a centralized `api` service instead of hardcoded `localhost:5000` URLs. This fixes `net::ERR_CONNECTION_REFUSED` errors on the deployed site.
    -   Fixes a URL construction bug in `tempIntakeService.js` to prevent double slashes, which was causing CORS preflight errors.