### PR TITLE
debug: Add detailed error logging to admin routes

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -61,7 +61,7 @@ router.get('/announcements/active', async (req, res) => {
     res.json(announcements);
   } catch (error) {
     console.error('Error fetching active announcements:', error);
-    res.status(500).json({ error: 'Failed to fetch active announcements' });
+    res.status(500).json({ error: error.message, stack: error.stack });
   }
 });
 
@@ -151,7 +151,7 @@ router.get('/health-tips/active', async (req, res) => {
     res.json(tips);
   } catch (error) {
     console.error('Error fetching active health tips:', error);
-    res.status(500).json({ error: 'Failed to fetch active health tips' });
+    res.status(500).json({ error: error.message, stack: error.stack });
   }
 });
 
@@ -174,7 +174,7 @@ router.get('/success-stories/active', async (req, res) => {
     res.json(stories);
   } catch (error) {
     console.error('Error fetching active success stories:', error);
-    res.status(500).json({ error: 'Failed to fetch active success stories' });
+    res.status(500).json({ error: error.message, stack: error.stack });
   }
 });
 


### PR DESCRIPTION
This is a temporary commit for debugging purposes.

- Modifies the error handling in the `announcements/active`, `health-tips/active`, and `success-stories/active` routes in `backend/src/routes/admin.js`.
- Instead of sending a generic "500" error, the backend will now send the detailed `error.message` and `error.stack`.
- This is intended to help diagnose a persistent 500 error that is occurring even when the required Firestore indexes are reportedly enabled.

NOTE: This change should be reverted once the underlying issue is solved, as exposing detailed error messages and stack traces in production is a security risk.